### PR TITLE
Add command-line control for training.py, update README.md

### DIFF
--- a/CNN/dicts/sp.txt
+++ b/CNN/dicts/sp.txt
@@ -1,1 +1,1 @@
-benbrooks
+Fucla

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 - Enter `CNN/` and run `python generation.py [keyword]` to generate a 50/50 training set with that specific word. The training set will be saved in `data_generation/` with keyword photos saved as t.NUM.jpg and false photos saved as f.NUM.jpg. This data is also not tracked by github.
 
 ## Step 4
-- Train a CNN binary classifier by running `python training.py`. We are still working to export the trained weights - for now you'll just be able to see some statistics about the resulting model.
+- Train a CNN binary classifier by running `python training.py -t <TEST_PERCENT> -e <EPOCHS> -l <LEARNING_RATE> -b <BATCH_SIZE>`. Note that all command-line options are optional, as we have hardcoded defaults for them: `python training.py` uses all defaults. We are still working to export the trained weights - for now you'll just be able to see some statistics about the resulting model.


### PR DESCRIPTION
This commit gives us command-line control over test/train percent, epochs, learning rate, and batch size. Also, I don't believe the SELECT_SUBSET_PERCENT constant is used in training.py, so I commented it out. If we don't need it, we can remove it on the next commit. Also, let me know if there are any other parameters you'd like to be able to control from the command line.